### PR TITLE
Don't grow textareas in width of the page

### DIFF
--- a/resumator-ui/src/styles/app.less
+++ b/resumator-ui/src/styles/app.less
@@ -105,6 +105,8 @@ li.active {
   }
 }
 
+textarea { max-width: 100%; }
+
 @media print {
   @page :first {
     margin-top: 10mm


### PR DESCRIPTION
## What did I do??

- Set max-width on textareas so you can not extend them in the width.