### PR TITLE
Stripping styles that may come along with coping from other websites

### DIFF
--- a/resumator-ui/src/js/components/shared/form/Experience.js
+++ b/resumator-ui/src/js/components/shared/form/Experience.js
@@ -9,6 +9,7 @@ import {
 import FormComponent from './Form';
 import countries from '../../../data/countries';
 import labelize from '../../../helpers/labelize';
+import stripStyles from '../../../helpers/stripStyles';
 
 function needToCheckTheBox(item) {
   let { currentlyWorkHere } = item;
@@ -40,7 +41,7 @@ class ExperienceForm extends FormComponent {
   }
 
   handleQuillChange(name, value) {
-    this.props.values[name] = value;
+    this.props.values[name] = stripStyles(value);
     this.props.handleChange('experience', this.props.currentValues);
   }
 

--- a/resumator-ui/src/js/components/shared/form/Form.js
+++ b/resumator-ui/src/js/components/shared/form/Form.js
@@ -10,12 +10,13 @@ import ReactQuill from 'react-quill';
 
 import moment from 'moment';
 import labelize from '../../../helpers/labelize';
+import stripStyles from '../../../helpers/stripStyles';
 import quillFormat from '../../../data/quill-formats';
 
 class FormComponent extends React.Component {
 
   handleQuillChange(name, value) {
-    this.props.handleChange(name, value);
+    this.props.handleChange(name, stripStyles(value));
   }
 
   getInput(name, type, required, placeholder, autoFocus, attrs) {

--- a/resumator-ui/src/js/components/shared/form/Personal.js
+++ b/resumator-ui/src/js/components/shared/form/Personal.js
@@ -5,6 +5,7 @@ import nationalities from '../../../data/nationalities';
 import countries from '../../../data/countries';
 import types from '../../../data/types';
 import labelize from '../../../helpers/labelize';
+import stripStyles from '../../../helpers/stripStyles';
 import FormComponent from './Form';
 
 class PersonalForm extends FormComponent {
@@ -13,7 +14,7 @@ class PersonalForm extends FormComponent {
   }
 
   handleQuillChange(name, value) {
-    this.props.handleChange(name, value);
+    this.props.handleChange(name, stripStyles(value));
   }
 
   renderFirstRow() {

--- a/resumator-ui/src/js/helpers/stripStyles.js
+++ b/resumator-ui/src/js/helpers/stripStyles.js
@@ -1,0 +1,4 @@
+
+export default function stripStyles(str) {
+  return str.replace(/style\=[\"\']?([a-zA-Z0-9 \:\-\#\(\)\.\_\/\;\'\,]+)\;?[\"\']?/ig, '');
+}

--- a/resumator-ui/test/unit/stripStyles.js
+++ b/resumator-ui/test/unit/stripStyles.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+
+import stripStyles from '../../src/js/helpers/stripStyles.js';
+
+const myValue = '<div><span style="color: rgb(255, 255, 255); font-family: Quattrocento Sans, Helvetica, Arial, sans-serif; font-size: 16px; background-color: rgb(16, 35, 114);">Old ladies die all the time. It s practically in the job description. Well, youre very similar heights. Maybe you should wear labels. Big scarf, bow tie, big embarrassing. No. That is not the question. That is not where we start. No sir. Thirteen! Come on, Team Not Dead. What do you think of the new look? I was hoping for minimalism, but I think I came up with magician. Mortuaries and larders. Easiest things to break out of. Shut up! Just shut up, shut up, shut up, shuttity up up up! I just have one question…&nbsp;do you know how to fly this thing?</span></div>';
+const compareValue = '<div><span >Old ladies die all the time. It s practically in the job description. Well, youre very similar heights. Maybe you should wear labels. Big scarf, bow tie, big embarrassing. No. That is not the question. That is not where we start. No sir. Thirteen! Come on, Team Not Dead. What do you think of the new look? I was hoping for minimalism, but I think I came up with magician. Mortuaries and larders. Easiest things to break out of. Shut up! Just shut up, shut up, shut up, shuttity up up up! I just have one question…&nbsp;do you know how to fly this thing?</span></div>';
+describe('stripStyles', () => {
+  it('should remove all style attrs from text', () => {
+    const strippedValue = stripStyles(myValue);
+    expect(strippedValue).to.equal(compareValue);
+  });
+});


### PR DESCRIPTION
## What did I do?

- Added helper function for matching and removing all `style` attributes from each inserted element
- Added unit test for this method
- Made sure all the Quill editors received this update